### PR TITLE
Remove Explicit Tracking Protection Settings

### DIFF
--- a/distribution/policies.json
+++ b/distribution/policies.json
@@ -9,12 +9,6 @@
         "DisablePocket": true,
         "DisableSetDesktopBackground": false,
         "DisableDeveloperTools": false,
-        "EnableTrackingProtection": {
-            "Value": true,
-            "Locked": true,
-            "Cryptomining": true,
-            "Fingerprinting": true
-        },
         "DNSOverHTTPS": {
             "Enabled": false,
             "ProviderURL": "",


### PR DESCRIPTION
These settings were overriding the Content Blocking category to custom instead of strict.

Will fix #17.